### PR TITLE
Added supervisor approval functionality for other accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,15 +7,16 @@ const cors = require('cors');
 const connectDB = require("./db/connect");
 const peopleRouter = require("./routes/people");
 const faultsRouter = require("./routes/faults");
-const accountsRouter = require("./routes/accounts"); // Import the accounts router
+const accountsRouter = require("./routes/accounts"); 
 
 app.use(express.json());
 app.use(cors());
 
+
 // Register routes
 app.use("/api/v1", peopleRouter);
 app.use("/api/v1/faults", faultsRouter);
-app.use("/api/v1/accounts", accountsRouter); // Add this line for accounts
+app.use("/api/v1/accounts", accountsRouter); 
 
 const port = process.env.PORT || 3000;
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,30 +1,53 @@
 import React, { useState, useEffect } from "react";
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, Link } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import LoginPage from "./components/LoginPage";
 import SignUpPage from "./components/SignUpPage";
 import FaultSubmissionForm from "./components/FaultSubmissionForm";
 import FaultList from "./components/FaultList";
- 
+import UnapprovedAccounts from "./components/UnapprovedAccounts"; 
+import SupervisorDashboard from "./components/SupervisorDashboard"; 
+
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [userType, setUserType] = useState("");
  
   // Load login state from localStorage when the app starts
   useEffect(() => {
     const storedLoginState = localStorage.getItem("isLoggedIn");
     if (storedLoginState === "true") {
       setIsLoggedIn(true);
+      fetchUserType();
     }
   }, []);
+
+  const fetchUserType = async () => {
+    try {
+      const storedUsername = localStorage.getItem("username");
+      if (!storedUsername) return;
+
+      const response = await fetch(`http://localhost:3000/api/v1/accounts/user-info?username=${storedUsername}`);
+      if (!response.ok) throw new Error("Failed to fetch user info");
+      const data = await response.json();
+      setUserType(data.accountType);
+      localStorage.setItem("userType", data.accountType);
+    } catch (error) {
+      console.error(error.message);
+    }
+  };
  
   const handleLogin = () => {
     setIsLoggedIn(true);
+    fetchUserType(); // Corrected: Fetch userType after login
     localStorage.setItem("isLoggedIn", "true"); // Save login state
   };
  
   const handleLogout = () => {
     setIsLoggedIn(false);
+    setUserType("");
     localStorage.removeItem("isLoggedIn"); // Remove login state
+    localStorage.removeItem("username");
+    localStorage.removeItem("userType");
   };
  
   return (
@@ -52,6 +75,10 @@ function App() {
                   </>
                 }
               />
+              {/* Supervisor Route */}
+              {userType === "supervisor" && (
+                <Route path="/supervisor-dashboard" element={<SupervisorDashboard />} />  
+              )}
             </>
           ) : (
             // Redirect to login if not logged in
@@ -66,6 +93,9 @@ function App() {
               position: "absolute",
               top: "10px",
               right: "25px",
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
             }}
           >
             <button
@@ -76,12 +106,30 @@ function App() {
                 borderRadius: "3px",
                 border: "none",
                 cursor: "pointer",
-                margin: "10px 0",
               }}
               onClick={handleLogout}
             >
               Sign Out
             </button>
+
+            {/* Supervisor Dashboard Button */}
+            {userType === "supervisor" && (
+              <Link to="/supervisor-dashboard" style={{ textDecoration: "none" }}>
+                <button
+                  style={{
+                    background: "#973c12",
+                    color: "white",
+                    padding: "10px 20px",
+                    borderRadius: "3px",
+                    border: "none",
+                    cursor: "pointer",
+                  }}
+                  onClick={() => navigate("/supervisor-dashboard")}
+                >
+                Supervisor Dashboard
+              </button>
+              </Link>
+            )}
           </div>
         )}
       </div>

--- a/client/src/components/LoginPage.jsx
+++ b/client/src/components/LoginPage.jsx
@@ -28,6 +28,7 @@ function LoginPage({ onLogin }) {
       // Handle success
       if (response.data.success) {
         console.log('Login successful:', response.data);
+        localStorage.setItem("username", username);
         onLogin(response.data); // Pass the logged-in user data to parent component
       }
     } catch (err) {
@@ -86,6 +87,8 @@ function LoginPage({ onLogin }) {
             {loading ? 'Logging in...' : 'Sign in'}
           </button>
         </form>
+
+
 
         {/* Sign Up Link */}
         <p

--- a/client/src/components/SupervisorDashboard.jsx
+++ b/client/src/components/SupervisorDashboard.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import "../styles/SupervisorDashboard.css";
+import { toast } from "react-toastify";
+
+const url = "http://localhost:3000/api/v1/accounts/unapproved"; // URL to fetch unapproved accounts
+
+const SupervisorDashboard = () => {
+  const [accounts, setAccounts] = useState([]);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const fetchUnapprovedAccounts = async () => {
+    try {
+      const response = await axios.get(url);
+      setAccounts(response.data.data || []); // Ensure we store an array
+    } catch (error) {
+      console.error("Error fetching unapproved accounts:", error);
+      toast.error("Failed to load unapproved accounts");
+    }
+  };
+
+  const approveAccount = async (userId) => {
+    try {
+      await axios.put(`http://localhost:3000/api/v1/accounts/approve/${userId}`);
+
+      // Remove the approved account from the list
+      setAccounts((prevAccounts) => prevAccounts.filter((account) => account._id !== userId));
+
+      toast.success("Account successfully approved!");
+    } catch (error) {
+      console.error("Approval error:", error);
+      toast.error("Failed to approve account");
+    }
+  };
+
+  useEffect(() => {
+    fetchUnapprovedAccounts();
+  }, []); // Fetch only on first render
+
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
+
+  return (
+    <div className="supervisor-dashboard">
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: "20px" }}>
+        <button onClick={toggleVisibility} className="toggle-dashboard-button">
+          {isVisible ? "Hide Unapproved Accounts" : "Show Unapproved Accounts"}
+        </button>
+      </div>
+
+      {isVisible && (
+        <div>
+          <h2>Unapproved Accounts:</h2>
+          <div className="account-items">
+            {accounts.length === 0 ? (
+              <p>No unapproved accounts.</p>
+            ) : (
+              accounts.map((account) => (
+                <div key={account._id} className="account-item">
+                  <p className="account-username">Username: {account.username}</p>
+                  <p className="account-type">Account Type: {account.accountType}</p>
+                  <div className="account-actions">
+                    <button onClick={() => approveAccount(account._id)} className="approve-btn">
+                      Approve
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SupervisorDashboard;

--- a/client/src/components/UnapprovedAccounts.jsx
+++ b/client/src/components/UnapprovedAccounts.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+
+const UnapprovedAccounts = () => {
+    const [accounts, setAccounts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        fetch("http://localhost:3000/api/v1/accounts/unapproved")
+            .then((res) => res.json())
+            .then((data) => {
+                setAccounts(data.data || []); // Ensure it's an array
+                setLoading(false);
+            })
+            .catch((error) => {
+                setError("Failed to load accounts");
+                setLoading(false);
+            });
+    }, []);
+
+    const approveAccount = async (userId) => {
+        try {
+            const response = await fetch(`http://localhost:3000/api/v1/accounts/approve/${userId}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+            });
+    
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || "Failed to approve account");
+            }
+    
+            // Remove the approved account from the list dynamically
+            setAccounts((prevAccounts) => prevAccounts.filter((account) => account._id !== userId));
+    
+        } catch (err) {
+            setError(err.message);
+        }
+    };
+    
+
+    if (loading) return <p>Loading...</p>;
+    if (error) return <p style={{ color: "red" }}>{error}</p>;
+
+    return (
+        <div style={{ padding: "20px" }}>
+            <h2>Unapproved Accounts</h2>
+            {accounts.length === 0 ? (
+                <p>No unapproved accounts.</p>
+            ) : (
+                <table border="1" cellPadding="10">
+                    <thead> {/* Fixed incorrect <thread> tag */}
+                        <tr>
+                            <th>Username</th>
+                            <th>Account Type</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {accounts.map((account) => (
+                            <tr key={account._id}>
+                                <td>{account.username}</td>
+                                <td>{account.accountType}</td>
+                                <td>
+                                    <button
+                                        style={{
+                                            background: "#28a745",
+                                            color: "#ffc317",
+                                            padding: "6px 12px",
+                                            border: "none",
+                                            cursor: "pointer",
+                                            borderRadius: "5px",
+                                        }}
+                                        onClick={() => approveAccount(account._id)}
+                                    >
+                                        Approve
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+};
+
+export default UnapprovedAccounts;

--- a/client/src/styles/SupervisorDashboard.css
+++ b/client/src/styles/SupervisorDashboard.css
@@ -1,0 +1,96 @@
+.supervisor-dashboard {
+    padding: 20px;
+    max-width: 1200px;
+    margin: auto;
+    background: #232f23; /* Dark Army Green */
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
+    color: #ffffff;
+    font-family: Arial, sans-serif;
+  }
+  
+  .supervisor-dashboard h2 {
+    text-align: center;
+    font-size: 24px;
+    margin-bottom: 20px;
+    color: #ffc317; /* Gold Title */
+  }
+  
+  /* Toggle Button */
+  .toggle-dashboard-button {
+    background-color: #ffc317;
+    color: #2a362a;
+    border: none;
+    padding: 12px 20px;
+    font-size: 16px;
+    font-weight: bold;
+    border-radius: 8px;
+    cursor: pointer;
+    display: block;
+    margin: 0 auto 20px;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+  }
+  
+  .toggle-dashboard-button:hover {
+    transform: scale(1.05);
+    background-color: #e6b813;
+  }
+  
+  /* Unapproved Accounts List */
+  .account-items {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr); /* Maximum 3 columns per row */
+    gap: 20px;
+    padding: 10px;
+    justify-content: center; /* Center items */
+  }
+  
+  /* Responsive - Single Column on Small Screens */
+  @media (max-width: 768px) {
+    .account-items {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  /* Account Card Styling */
+  .account-item {
+    background: #2a362a; /* Dark Green Background */
+    border: 1px solid #ffc317; /* Gold Border */
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  }
+  
+  /* Account Info */
+  .account-username {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    color: #ffc317; /* Gold */
+  }
+  
+  .account-type {
+    font-size: 16px;
+    font-weight: bold;
+    margin: 10px 0;
+    color: #ffffff;
+  }
+  
+  /* Approve Button */
+  .approve-btn {
+    background: #28a745; /* Green for Approval */
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    transition: background 0.3s, transform 0.2s;
+  }
+  
+  .approve-btn:hover {
+    background: #218838;
+    transform: translateY(-2px);
+  }
+  

--- a/models/Account.js
+++ b/models/Account.js
@@ -9,10 +9,12 @@ const AccountSchema = new mongoose.Schema({
         enum: ['clerk', 'maintainer', 'manager', 'operator', 'supervisor'],
         required: true,
     },
+    isActive: {type: Boolean, default: false, required: false},
 });
 
 // Pre-save hook to hash password
 AccountSchema.pre("save", async function () {
+    if (!this.isModified("password")) return;
     const salt = await bcrypt.genSalt(10);
     this.password = await bcrypt.hash(this.password, salt);
 });
@@ -37,5 +39,26 @@ AccountSchema.statics.createUser = async function (supervisorId, userDetails) {
     const newUser = new this(userDetails);
     return await newUser.save();
 };
+
+AccountSchema.statics.activateUser = async function (supervisorId, userId) {
+    const supervisor = await this.findById(supervisorId);
+    if (!supervisor || supervisor.accountType !== 'supervisor') {
+        throw new Error('Only supervisors can activate accounts');
+    }
+
+    const user = await this.findById(userId);
+    if (!user) {
+        throw new Error('User not found');
+    }
+
+    if (user.isActive) {
+        throw new Error('User is already active');
+    }
+
+    user.isActive = true;
+    await user.save();
+    return user;
+
+}
 
 module.exports = mongoose.model("Account", AccountSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^16.4.7",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
-        "mongoose": "^8.0.3"
+        "mongoose": "^8.0.3",
+        "react-router-dom": "^7.1.5"
       },
       "devDependencies": {
         "nodemon": "^3.0.2"
@@ -27,6 +28,12 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.10.5",
@@ -1037,6 +1044,78 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.5.tgz",
+      "integrity": "sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
+      "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.1.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1072,6 +1151,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -1129,6 +1215,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.1.1",
@@ -1249,6 +1341,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
-    "mongoose": "^8.0.3"
+    "mongoose": "^8.0.3",
+    "react-router-dom": "^7.1.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -1,8 +1,42 @@
 const express = require("express");
 const router = express.Router();
-const { createAccount, createAccountAsSupervisor, getAccounts, loginUser } = require("../controllers/accounts");
+const { createAccount, createAccountAsSupervisor, getAccounts, loginUser, getUnapprovedAccounts, approveAccount } = require("../controllers/accounts");
+
+const Account = require ("../models/Account")
+
+
 
 // Routes
+
+
+router.get("/test-route", (req, res) => {
+    res.send("✅ The /test-route is working!");
+});
+
+router.get("/user-info", async (req, res) => {
+
+
+    try {
+        const { username } = req.query;
+
+        if(!username) {
+            return res.status(400).json({ success: false, message: "Username required" });
+        }
+
+        const user = await Account.findOne({ username });
+        if (!user) {
+            return res.status(404).json({ success: false, message: "User not found" });
+        }
+
+        res.json({ accountType: user.accountType });
+
+    } catch(error) {
+        console.error("Error:", error.message);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+
 router.route("/")
     .post(createAccount) // General account creation
     .get(getAccounts);   // Get all accounts
@@ -12,5 +46,13 @@ router.route("/supervisor")
 
 router.route("/login")
     .post(loginUser); // Login route
+
+router.route("/unapproved")
+    .get(getUnapprovedAccounts); // Get all unapproved accounts
+
+router.route("/approve/:userId")
+    .put(approveAccount); // Approve an account
+
+
 
 module.exports = router;


### PR DESCRIPTION
When a supervisor logs in there is a new button on the right side only for supervisors which navigates to a supervisor dashboard.
The dashboard is mainly a placeholder until we add the other functionality but for now it has a feature which handles the account approval

If testing locally the best way to setup the first supervisor is to sign up an account and manually activate it in the database, then from there any future accounts can be approved by the created supervisor