### PR TITLE
Maintainer can claim faults, ordered by creation date

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,8 +35,10 @@ function App() {
       if (!response.ok) throw new Error("Failed to fetch user info");
       const data = await response.json();
       setUserType(data.accountType);
-      console.log("Fetched data: " ,data)
+      
       localStorage.setItem("userType", data.accountType);
+      localStorage.setItem("userID", data._id);
+
     } catch (error) {
       console.error(error.message);
     }
@@ -54,6 +56,7 @@ function App() {
     localStorage.removeItem("isLoggedIn"); // Remove login state
     localStorage.removeItem("username");
     localStorage.removeItem("userType");
+    localStorage.removeItem("userID");
   };
 
   return (

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,8 @@ import UnapprovedAccounts from "./components/UnapprovedAccounts";
 import SupervisorDashboard from "./components/SupervisorDashboard"; 
 import HomeScreen from "./components/HomeScreen";
 import CompletedFaultList from "./components/CompletedFaultList";
+import ClaimFaults from "./components/ClaimFaults";
+import ClaimedFaults from "./components/ClaimedFaults";
 
 
 function App() {
@@ -33,6 +35,7 @@ function App() {
       if (!response.ok) throw new Error("Failed to fetch user info");
       const data = await response.json();
       setUserType(data.accountType);
+      console.log("Fetched data: " ,data)
       localStorage.setItem("userType", data.accountType);
     } catch (error) {
       console.error(error.message);
@@ -90,6 +93,10 @@ function App() {
                   </>
                 }
               />
+
+              <Route path="/claim-faults" element={<ClaimFaults />} />
+              <Route path="/claimed-faults" element={<ClaimedFaults />} />
+              
               {/* Supervisor Route */}
               {userType === "supervisor" && (
                 <Route path="/supervisor-dashboard" element={<SupervisorDashboard />} />  

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -34,10 +34,11 @@ function App() {
       const response = await fetch(`http://localhost:3000/api/v1/accounts/user-info?username=${storedUsername}`);
       if (!response.ok) throw new Error("Failed to fetch user info");
       const data = await response.json();
+      console.log("Fetched data: " , data)
       setUserType(data.accountType);
       
       localStorage.setItem("userType", data.accountType);
-      localStorage.setItem("userID", data._id);
+      localStorage.setItem("userID", data.userID);
 
     } catch (error) {
       console.error(error.message);

--- a/client/src/components/ClaimFaults.jsx
+++ b/client/src/components/ClaimFaults.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import "../styles/ClaimFaults.css"; // or reuse FaultList.css
+import axios from "axios"; // #2: import axios for "patch" requests
+import { toast } from "react-toastify"; // #3: if you want to show success messages
+import { store } from "../store"; // #4: if you want to dispatch a global status
+import { changeStatusListener } from "../features/globalValues/globalSlice"; // #5 
+
+
+const ClaimFaults = () => {
+  const [pendingFaults, setPendingFaults] = useState([]);
+  const navigate = useNavigate();
+
+  // We'll fetch from the same base URL as in FaultList
+
+  const url = "http://localhost:3000/api/v1/faults"; 
+
+  useEffect(() => {
+    fetchPendingFaults();
+  }, []);
+
+  const fetchPendingFaults = async () => {
+    try {
+      // Just like in your existing code
+      const response = await axios.get(url);
+      const data = response.data; // {faults, count}
+
+      if (data.faults) {
+        // If status is an array, check includes("pending")
+        const pending = data.faults.filter(fault =>
+          Array.isArray(fault.status)
+            ? fault.status.includes("pending")
+            : fault.status === "pending"
+        );
+        setPendingFaults(pending);
+      }
+    } catch (error) {
+      console.error("Error fetching faults:", error);
+    }
+  };
+
+
+  const claimFault = async (faultID) => {
+    try {
+      const maintainerID = localStorage.getItem("userID");
+      if (!maintainerID) {
+        alert("Error: No user ID found in localStorage.");
+        return;
+      }
+  
+      const response = await axios.patch(`${url}/${faultID}/claim`, { maintainerID });
+  
+      if (response.status === 200) {
+        // Remove claimed fault from the list
+        setPendingFaults(prev => prev.filter(f => f._id !== faultID));
+        toast.success("Fault claimed successfully!");
+      } else {
+        toast.error("Failed to claim fault.");
+      }
+    } catch (error) {
+      toast.error(error.response?.data?.msg || "Error claiming fault");
+      console.error("Error claiming fault:", error);
+    }
+  };
+  
+  
+  return (
+    <div className="claim-faults-main">
+      <button className="back-button" onClick={() => navigate("/home")}>
+        Back
+      </button>
+
+      <h2 className="claim-faults-title">Pending Faults</h2>
+
+      <div className="fault-items">
+        {pendingFaults.length === 0 ? (
+          <p>No pending faults available.</p>
+        ) : (
+          pendingFaults.map((fault) => (
+            <div key={fault._id} className="fault-item">
+              <p className="vehicle-id">Vehicle ID: {fault.vehicleId}</p>
+              <p className="fault-issues">Issues:</p>
+              <ul className="issues-list">
+                {fault.issues.map((issue, index) => (
+                  <li key={index} className="issue-item">
+                    {issue}
+                  </li>
+                ))}
+              </ul>
+              <div className="fault-actions">
+                <button
+                  onClick={() => claimFault(fault._id)}
+                  className="correct-btn" /* same style as "Fault Corrected" */
+                >
+                  Claim Fault
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ClaimFaults;

--- a/client/src/components/ClaimedFaults.jsx
+++ b/client/src/components/ClaimedFaults.jsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import "../styles/ClaimFaults.css"; // Using same styles as ClaimFaults
+import { changeStatusListener } from "../features/globalValues/globalSlice";
+import { store } from "../store";
+import { useDispatch, useSelector } from "react-redux";
+import { toast } from "react-toastify";
+
+const ClaimedFaults = () => {
+  const navigate = useNavigate();
+  const [faults, setFaults] = useState([]);
+  const dispatch = useDispatch();
+  const maintainerID = localStorage.getItem("userID");
+  const { statusListener } = useSelector((state) => state.globalValues);
+
+  const fetchClaimedFaults = async () => {
+    try {
+      const response = await axios.get("http://localhost:3000/api/v1/faults");
+      
+      // Filter only the faults that are claimed AND claimedBy the current maintainer
+      const claimed = response.data.faults.filter((fault) => {
+        const isClaimed = Array.isArray(fault.status)
+          ? fault.status.includes("claimed")
+          : fault.status === "claimed";
+  
+        const isClaimedByMe = fault.claimedBy === maintainerID;
+        return isClaimed && isClaimedByMe;
+      });
+  
+      setFaults(claimed);
+    } catch (error) {
+      console.error(error);
+      toast.error("Error fetching claimed faults");
+    }
+  };
+  const deleteFault = async (id) => {
+    try {
+      await axios.delete(`http://localhost:3000/api/v1/faults/${id}`);
+      setFaults((prevFaults) => prevFaults.filter((fault) => fault._id !== id));
+      store.dispatch(changeStatusListener());
+      toast.success("Fault successfully deleted");
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const correctFault = async (id) => {
+    try {
+      console.log("Correcting fault with ID:", id);
+      console.log(`Send PATCH request to: http://localhost:3000/api/v1/faults/${id}/correct`);
+      
+      await axios.patch(`http://localhost:3000/api/v1/faults/${id}/correct`);
+      
+      // Remove the corrected fault from the UI
+      setFaults((prevFaults) => prevFaults.filter((fault) => fault._id !== id));
+      
+      store.dispatch(changeStatusListener());
+      toast.success("Fault marked as corrected");
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  useEffect(() => {
+    fetchClaimedFaults();
+  }, [statusListener]);
+
+  return (
+    <div className="claim-faults-main">
+      <button className="back-button" onClick={() => navigate("/home")}>
+        Back
+      </button>
+      <div>
+        <h2 className="claim-faults-title">My Claimed Faults</h2>
+
+        <div className="fault-list-container">
+          <div className="fault-items">
+            {faults.length === 0 ? (
+              <p>No claimed faults found.</p>
+            ) : (
+              faults.map((fault) => (
+                <div key={fault._id} className="fault-item">
+                  <p className="vehicle-id">Vehicle ID: {fault.vehicleId}</p>
+                  <p className="fault-issues">Issues:</p>
+                  <ul className="issues-list">
+                    {fault.issues.map((issue, index) => (
+                      <li key={index} className="issue-item">
+                        {issue}
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="fault-actions">
+                    <button
+                      onClick={() => deleteFault(fault._id)}
+                      className="delete-btn"
+                    >
+                      Delete
+                    </button>
+                    <button
+                      onClick={() => correctFault(fault._id)}
+                      className="correct-btn"
+                    >
+                      Fault Corrected
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClaimedFaults;

--- a/client/src/components/Menu.jsx
+++ b/client/src/components/Menu.jsx
@@ -29,6 +29,12 @@ const Menu = ({ userType }) => {
           <button onClick={() => navigate("/fault-list")}>
             Check Reported Faults
           </button>
+          <button onClick={() => navigate("/claim-faults")}>
+            Claim Faults
+          </button>
+          <button onClick={() => navigate("/claimed-faults")}>
+            Claimed Faults
+          </button>
         </>
       )}
 

--- a/client/src/styles/ClaimFaults.css
+++ b/client/src/styles/ClaimFaults.css
@@ -1,0 +1,112 @@
+ .claim-faults-main {
+    padding: 20px;
+    max-width: 1200px;
+    margin: auto;
+    background: #232f23; /* Dark Army green */
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
+    color: #ffffff;
+    font-family: Arial, sans-serif;
+  }
+  
+  .claim-faults-title {
+    text-align: center;
+    font-size: 24px;
+    margin-bottom: 20px;
+    color: #ffc317; /* Army gold */
+  }
+  
+  .fault-items {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  
+  .fault-item {
+    background: #2a362a;
+    border: 1px solid #ffc317;
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+    
+    /* Ensures all boxes are the same height */
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 250px; /* Fixed height for consistency */
+  }
+  
+  .vehicle-id {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    color: #ffc317;
+  }
+  
+  .fault-issues {
+    font-size: 16px;
+    font-weight: bold;
+    margin: 10px 0;
+  }
+  
+  /* Scrollable issues list inside the box */
+  .issues-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 80px; /* Limit height to ensure scrolling */
+    overflow-y: auto;
+    scrollbar-width: thin; /* Firefox */
+    scrollbar-color: #ffc317 #2a362a; /* Gold scrollbar */
+  }
+  
+  .issues-list::-webkit-scrollbar {
+    width: 6px;
+  }
+  
+  .issues-list::-webkit-scrollbar-thumb {
+    background: #ffc317;
+    border-radius: 5px;
+  }
+  
+  .issue-item {
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  
+  /* Claim button always at bottom */
+  .fault-actions {
+    margin-top: auto; /* Pushes the button to the bottom */
+    display: flex;
+    justify-content: center;
+  }
+  
+  .claim-btn {
+    background: #ffc317; /* Gold */
+    color: #2a362a;
+    border: none;
+    padding: 10px 18px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    transition: background 0.3s, transform 0.2s;
+    width: 100%; /* Ensures consistency */
+  }
+  
+  .claim-btn:hover {
+    background: #e6b813;
+    transform: translateY(-2px);
+  }
+  
+  /* Responsive adjustments */
+  @media (max-width: 768px) {
+    .fault-items {
+      grid-template-columns: 1fr;
+    }
+  
+    .fault-item {
+      height: auto; /* Allows flexible height on smaller screens */
+    }
+  }
+  

--- a/controllers/accounts.js
+++ b/controllers/accounts.js
@@ -108,7 +108,6 @@ const loginUser = async (req, res) => {
             data: {
                 username: user.username,
                 accountType: user.accountType,
-                userID: user._id,
             },
         });
     } catch (error) {

--- a/controllers/accounts.js
+++ b/controllers/accounts.js
@@ -108,6 +108,7 @@ const loginUser = async (req, res) => {
             data: {
                 username: user.username,
                 accountType: user.accountType,
+                userID: user._id,
             },
         });
     } catch (error) {

--- a/controllers/faults.js
+++ b/controllers/faults.js
@@ -3,6 +3,7 @@ const Fault = require("../models/Fault");
 const getAllFaults = async (req, res) => {
     try {
         const faults = await Fault.find({});
+
         res.status(200).json({ faults, count: faults.length });
     } catch (error) {
         res.status(500).json({ message: error.message });
@@ -96,6 +97,25 @@ const deleteFault = async (req, res) => {
     }
 };
 
+const claimFault = async (req, res) => {
+    try {
+      const { id: faultID } = req.params;
+      const { maintainerID } = req.body; 
+  
+      const updatedFault = await Fault.findByIdAndUpdate(faultID, 
+        { status: "claimed", claimedBy: maintainerID }, 
+        { new: true }
+    );
+    if (!updatedFault) {
+        return res.status(404).json({ msg: `Fault with ID ${faultID} doesn't exist` });
+    }
+    res.status(200).json({ updateFault });
+    
+    } catch (error) {
+        res.status(500).json({ message: `Error marking fault as corrected: ${error.message}` });
+    }
+  };
+
 
 module.exports = {
     getAllFaults,
@@ -106,4 +126,5 @@ module.exports = {
     updateFault,
     markFaultCorrected,
     deleteFault,
+    claimFault,
 };

--- a/controllers/faults.js
+++ b/controllers/faults.js
@@ -98,9 +98,11 @@ const deleteFault = async (req, res) => {
 };
 
 const claimFault = async (req, res) => {
+    
     try {
       const { id: faultID } = req.params;
       const { maintainerID } = req.body; 
+      console.log("maintainerID: ", maintainerID);
   
       const updatedFault = await Fault.findByIdAndUpdate(faultID, 
         { status: "claimed", claimedBy: maintainerID }, 

--- a/models/Fault.js
+++ b/models/Fault.js
@@ -11,7 +11,7 @@ const FaultSchema = new mongoose.Schema({
     },
     status: {
         type: [String],
-        enum: ["pending", "completed"],
+        enum: ["pending","claimed", "completed"],
         default: "pending",
     },
     customIssue: {
@@ -20,8 +20,15 @@ const FaultSchema = new mongoose.Schema({
     },
     createdAt: {
         type: Date,
-        default: Date.now
+        default: Date.now,
+        index: true
+    },
+    claimedBy: {
+        type: String,
+        default: null
     }
 });
+
+FaultSchema.index({ createdAt: 1 }); //stores indexes from oldest creation to newest
 
 module.exports = mongoose.model("Fault", FaultSchema);

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -9,9 +9,6 @@ const Account = require ("../models/Account")
 // Routes
 
 
-router.get("/test-route", (req, res) => {
-    res.send("✅ The /test-route is working!");
-});
 
 router.get("/user-info", async (req, res) => {
 
@@ -28,7 +25,7 @@ router.get("/user-info", async (req, res) => {
             return res.status(404).json({ success: false, message: "User not found" });
         }
 
-        res.json({ accountType: user.accountType });
+        res.json({ accountType: user.accountType , userID: user._id });
 
     } catch(error) {
         console.error("Error:", error.message);

--- a/routes/faults.js
+++ b/routes/faults.js
@@ -1,11 +1,12 @@
 const express = require("express");
 const router = express.Router();
-const { getAllFaults, getPendingFaults, getCompletedFaults, addFault, getFault, updateFault, markFaultCorrected, deleteFault } = require("../controllers/faults");
+const { getAllFaults, getPendingFaults, getCompletedFaults, addFault, getFault, updateFault, markFaultCorrected, deleteFault, claimFault } = require("../controllers/faults");
 
 router.route("/").get(getAllFaults).post(addFault);
 router.route("/pending").get(getPendingFaults);
 router.route("/completed").get(getCompletedFaults);
 router.route("/:id").get(getFault).patch(updateFault).delete(deleteFault); // Ensure this line exists
 router.route("/:id/correct").patch(markFaultCorrected);
+router.route("/:id/claim").patch(claimFault);
 
 module.exports = router;


### PR DESCRIPTION
Created 2 new pages that are viewable only by maintainer:
ClaimFaults
ClaimedFaults
ClaimFaults gives the maintainer a list of all currently "pending" faults and lets them claim it which will let them view it for later, only 1 maintainer can claim a fault.
ClaimedFaults is the view of all "claimed" faults where the current maintainer was the one to have claimed. 
Currently ClaimedFaults acts very similarly to Check Reported Faults except ClaimedFaults has some viewing restrictions. I chose to leave it in as we may use the Check Reported Faults as a view all function for the supervisors later on.