### PR TITLE
added the ability to edit faults

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -116,6 +116,7 @@ function App() {
               <Route path="/fault-list" element={<FaultList />} />
               <Route path="/completed-faults" element={<CompletedFaultList />} />
               <Route path="/operator-faults" element={<OperatorFaultList />} />
+              <Route path="/reopen-fault/:faultId" element={<FaultSubmissionForm isReopenMode={true} />} />
               <Route
                 path="/fault-submission"
                 element={

--- a/client/src/components/OperatorFaultList.jsx
+++ b/client/src/components/OperatorFaultList.jsx
@@ -7,28 +7,22 @@ import { toast } from "react-toastify";
 const OperatorFaultList = () => {
   const navigate = useNavigate();
   const [faults, setFaults] = useState([]);
-  const [partsByFault, setPartsByFault] = useState({}); // to store arrays of parts keyed by faultId
+  const [partsByFault, setPartsByFault] = useState({});
   const username = localStorage.getItem("username");
 
   useEffect(() => {
     fetchFaults();
   }, []);
 
-  // 1️⃣ Fetch the operator's faults (by username)
   const fetchFaults = async () => {
     try {
       const response = await axios.get(
         `http://localhost:3000/api/v1/faults/operator/${username}`
       );
       const faultData = response.data.faults;
-      
-      // Add debugging logs
-      console.log('Fetched operator faults:', faultData);
-      console.log('Sample fault deletedAt:', faultData[0]?.deletedAt);
-      
       setFaults(faultData);
 
-      // 2️⃣ For each fault, fetch its parts
+      // Fetch parts for each fault
       faultData.forEach((fault) => {
         fetchPartsForFault(fault._id);
       });
@@ -38,22 +32,23 @@ const OperatorFaultList = () => {
     }
   };
 
-  // 2️⃣ For each fault, fetch parts referencing that fault
   const fetchPartsForFault = async (faultId) => {
     try {
-      // Use the ?fault=faultId query param (your parts controller supports this)
       const response = await axios.get(
         `http://localhost:3000/api/v1/parts?fault=${faultId}`
       );
-
       if (response.data.success) {
-        const parts = response.data.data; // array of PartOrder docs
-        // Store them under this fault in our partsByFault state
+        const parts = response.data.data;
         setPartsByFault((prev) => ({ ...prev, [faultId]: parts }));
       }
     } catch (error) {
       console.error("Failed to fetch parts for fault:", error);
     }
+  };
+
+  // NEW: Handler to navigate to an "edit fault" page/component
+  const handleEditFault = (faultId) => {
+    navigate(`/edit-fault/${faultId}`); 
   };
 
   return (
@@ -67,26 +62,34 @@ const OperatorFaultList = () => {
 
         <div className="fault-items">
           {faults.map((fault) => {
-            // The array of parts for this particular fault
             const faultParts = partsByFault[fault._id] || [];
 
             return (
-              <div key={fault._id} className={`fault-item ${fault.status === 'deleted' ? 'deleted-fault' : ''}`}>
+              <div
+                key={fault._id}
+                className={`fault-item ${
+                  fault.status === "deleted" ? "deleted-fault" : ""
+                }`}
+              >
                 <p className="vehicle-id">Vehicle ID: {fault.vehicleId}</p>
-                {fault.status === 'deleted' && (
-                    <div className="deleted-banner">
-                        <p>DELETED</p>
-                        <p className="deleted-info">
-                            Deleted on: {fault.deletedAt ? new Date(fault.deletedAt).toLocaleString('en-US', {
-                                year: 'numeric',
-                                month: 'numeric',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                            }) : 'Unknown date'}
-                        </p>
-                    </div>
+                {fault.status === "deleted" && (
+                  <div className="deleted-banner">
+                    <p>DELETED</p>
+                    <p className="deleted-info">
+                      Deleted on:{" "}
+                      {fault.deletedAt
+                        ? new Date(fault.deletedAt).toLocaleString("en-US", {
+                            year: "numeric",
+                            month: "numeric",
+                            day: "numeric",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          })
+                        : "Unknown date"}
+                    </p>
+                  </div>
                 )}
+
                 <p className="fault-issues">Issues:</p>
                 <ul className="issues-list">
                   {fault.issues.map((issue, index) => (
@@ -96,10 +99,10 @@ const OperatorFaultList = () => {
                   ))}
                 </ul>
                 <p className="fault-status">
-                  <strong>Status:</strong> {fault.status === 'deleted' ? 'Deleted' : fault.status}
+                  <strong>Status:</strong>{" "}
+                  {fault.status === "deleted" ? "Deleted" : fault.status}
                 </p>
 
-                {/* Display maintainer comments if available */}
                 {fault.maintainerComment ? (
                   <div className="maintainer-comment">
                     <p className="comment-label">Maintainer Notes:</p>
@@ -111,7 +114,6 @@ const OperatorFaultList = () => {
                   </div>
                 )}
 
-                {/* 3️⃣ Display the parts associated with this fault */}
                 <div className="parts-section">
                   <h4 className="parts-title">Parts for this Fault:</h4>
                   {faultParts.length === 0 ? (
@@ -132,6 +134,15 @@ const OperatorFaultList = () => {
                     </ul>
                   )}
                 </div>
+
+                {/* NEW: Edit button (can disable if 'deleted') */}
+                <button
+                  className="edit-button"
+                  onClick={() => navigate(`/reopen-fault/${fault._id}`)}
+                  disabled={fault.status === "deleted"}
+                >
+                  Edit Fault
+                </button>
               </div>
             );
           })}

--- a/models/Fault.js
+++ b/models/Fault.js
@@ -2,8 +2,16 @@ const mongoose = require("mongoose");
 
 // Required schema for fault objects
 const FaultSchema = new mongoose.Schema({
+    vehicleType: {                   // <-- NEW field
+        type: String,
+        required: true
+    },
     vehicleId: {
         type: String,
+        required: true
+    },
+    timelines: {
+        type: [String],
         required: true
     },
     issues: {


### PR DESCRIPTION
This PR adds support for editing/reopening faults in the Fault Submission Form by pre-filling fields based on existing fault data. It also introduces schema-level support for vehicleType and timelines, which are required for the form to properly reload state.

✅ Changes Made
FaultSubmissionForm.jsx

Added useParams() to retrieve fault ID from route for editing mode.

Introduced isReopenMode prop to conditionally fetch existing fault data.

Used axios.get() to load fault data and prepopulate:

vehicleType

vehicleId

timelines

issues

Modified handleConfirmSubmit() to PATCH if editing and POST otherwise.

Ensured the form advances all steps automatically when in edit mode.

App.jsx

Added new route: /reopen-fault/:faultId → FaultSubmissionForm with isReopenMode={true}

models/fault.js

Added vehicleType (string, required).

Added timelines (array of strings, required) to schema.

These are now stored when faults are created and fetched during edits.

OperatorFaultList.jsx

Hooked up "Edit Fault" button to navigate to /reopen-fault/:faultId.

🧪 Testing
Verified that new faults submit correctly with all fields.

Verified that reopening a fault prepopulates the form and allows submission.

Handled case where a fault has missing or malformed fields gracefully.

Confirmed no regression in existing fault creation flow.

📌 Notes
Existing fault documents in the database may need to be updated manually to include the vehicleType and timelines fields.
